### PR TITLE
Update statistics summary when algo instance is stopped. When hitting…

### DIFF
--- a/src/Lykke.AlgoStore.Api/Controllers/AlgoStoreManagementController.cs
+++ b/src/Lykke.AlgoStore.Api/Controllers/AlgoStoreManagementController.cs
@@ -5,6 +5,7 @@ using Lykke.AlgoStore.Api.Infrastructure.Extensions;
 using Lykke.AlgoStore.Api.Models;
 using Lykke.AlgoStore.Core.Domain.Entities;
 using Lykke.AlgoStore.Core.Services;
+using Lykke.AlgoStore.CSharp.AlgoTemplate.Models.Enumerators;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -16,10 +17,12 @@ namespace Lykke.AlgoStore.Api.Controllers
     public class AlgoStoreManagementController : Controller
     {
         private readonly IAlgoStoreService _service;
+        private readonly IAlgoStoreStatisticsService _statisticsService;
 
-        public AlgoStoreManagementController(IAlgoStoreService service)
+        public AlgoStoreManagementController(IAlgoStoreService service, IAlgoStoreStatisticsService algoStoreStatisticsService)
         {
             _service = service;
+            _statisticsService = algoStoreStatisticsService;
         }
 
         [HttpPost("deploy/binary")]
@@ -65,6 +68,11 @@ namespace Lykke.AlgoStore.Api.Controllers
 
             var result = new StatusModel();
             result.Status = await _service.StopTestImageAsync(data);
+
+            if (result.Status == AlgoInstanceStatus.Stopped.ToString())
+            {
+                await _statisticsService.UpdateStatisticsSummaryAsync(data.ClientId, data.InstanceId);
+            }
 
             return Ok(result);
         }

--- a/src/Lykke.AlgoStore.Api/Controllers/AlgoStoreStatisticsController.cs
+++ b/src/Lykke.AlgoStore.Api/Controllers/AlgoStoreStatisticsController.cs
@@ -16,10 +16,12 @@ namespace Lykke.AlgoStore.Api.Controllers
     public class AlgoStoreStatisticsController : Controller
     {
         private readonly IAlgoStoreStatisticsService _statisticsService;
+        private readonly IAlgoStoreClientDataService _algoStoreClientDataService;
 
-        public AlgoStoreStatisticsController(IAlgoStoreStatisticsService statisticsService)
+        public AlgoStoreStatisticsController(IAlgoStoreStatisticsService statisticsService, IAlgoStoreClientDataService algoStoreClientDataService)
         {
             _statisticsService = statisticsService;
+            _algoStoreClientDataService = algoStoreClientDataService;
         }
 
         [HttpGet]
@@ -28,7 +30,13 @@ namespace Lykke.AlgoStore.Api.Controllers
         [ProducesResponseType(typeof(BaseErrorResponse), (int)HttpStatusCode.InternalServerError)]
         public async Task<IActionResult> GetAlgoInstanceStatisticsAsync(string instanceId)
         {
-            var result = await _statisticsService.GetAlgoInstanceStatisticsAsync(User.GetClientId(), instanceId);
+            StatisticsSummary result;
+            var algoInstance = await _algoStoreClientDataService.GetAlgoInstanceDataAsync(User.GetClientId(), instanceId);
+            
+            if (algoInstance.AlgoInstanceStatus == CSharp.AlgoTemplate.Models.Enumerators.AlgoInstanceStatus.Stopped)
+                result = await _statisticsService.GetStatisticsSummaryAsync(User.GetClientId(), instanceId);
+            else
+                result = await _statisticsService.UpdateStatisticsSummaryAsync(User.GetClientId(), instanceId);
 
             return Ok(result);
         }

--- a/src/Lykke.AlgoStore.Core/Lykke.AlgoStore.Core.csproj
+++ b/src/Lykke.AlgoStore.Core/Lykke.AlgoStore.Core.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lykke.AlgoStore.CSharp.AlgoTemplate.Models" Version="1.0.31-beta" />
+    <PackageReference Include="Lykke.AlgoStore.CSharp.AlgoTemplate.Models" Version="1.0.34-beta" />
     <PackageReference Include="Lykke.AzureQueueIntegration" Version="2.0.1" />
     <PackageReference Include="Lykke.Common" Version="4.5.0" />
     <PackageReference Include="Lykke.Service.Assets.Client" Version="3.3.2" />

--- a/src/Lykke.AlgoStore.Core/Services/IAlgoStoreClientDataService.cs
+++ b/src/Lykke.AlgoStore.Core/Services/IAlgoStoreClientDataService.cs
@@ -21,6 +21,7 @@ namespace Lykke.AlgoStore.Core.Services
         Task<List<AlgoClientInstanceData>> GetAllAlgoInstanceDataByClientIdAsync(string clientId);
 
         Task<AlgoClientInstanceData> GetAlgoInstanceDataAsync(CSharp.AlgoTemplate.Models.Models.BaseAlgoInstance data);
+        Task<AlgoClientInstanceData> GetAlgoInstanceDataAsync(string clientId, string instanceId);
         Task<AlgoClientInstanceData> SaveAlgoInstanceDataAsync(AlgoClientInstanceData data, string algoClientId);
         Task<AlgoClientMetaDataInformation> GetAlgoMetaDataInformationAsync(string clientId, string algoId);
         Task<AlgoRatingData> SaveAlgoRatingAsync(AlgoRatingData data);

--- a/src/Lykke.AlgoStore.Core/Services/IAlgoStoreStatisticsService.cs
+++ b/src/Lykke.AlgoStore.Core/Services/IAlgoStoreStatisticsService.cs
@@ -5,6 +5,7 @@ namespace Lykke.AlgoStore.Core.Services
 {
     public interface IAlgoStoreStatisticsService
     {
-        Task<StatisticsSummary> GetAlgoInstanceStatisticsAsync(string clientId, string instanceId);
+        Task<StatisticsSummary> GetStatisticsSummaryAsync(string clientId, string instanceId);
+        Task<StatisticsSummary> UpdateStatisticsSummaryAsync(string clientId, string instanceId);
     }
 }

--- a/src/Lykke.AlgoStore.Services/AlgoStoreClientDataService.cs
+++ b/src/Lykke.AlgoStore.Services/AlgoStoreClientDataService.cs
@@ -552,6 +552,18 @@ namespace Lykke.AlgoStore.Services
             });
         }
 
+        /// <summary>
+        /// Gets the algo instance data by ClientId asynchronous.
+        /// </summary>
+        /// <param name="clientId">The Id of the user.</param>
+        /// <param name="instanceId">The Id of the algo instance.</param>
+        /// <returns></returns>
+        public async Task<AlgoClientInstanceData> GetAlgoInstanceDataAsync(string clientId, string instanceId)
+        {
+            return await LogTimedInfoAsync(nameof(GetAlgoInstanceDataAsync), clientId, async () =>
+                await _instanceRepository.GetAlgoInstanceDataByClientIdAsync(clientId, instanceId));
+        }
+
         public async Task<List<AlgoClientInstanceData>> GetAllAlgoInstanceDataByClientIdAsync(string clientId)
         {
             return await LogTimedInfoAsync(nameof(GetAllAlgoInstanceDataByClientIdAsync), clientId, async () =>
@@ -645,8 +657,10 @@ namespace Lykke.AlgoStore.Services
             await _statisticsRepository.CreateOrUpdateSummaryAsync(new StatisticsSummary
             {
                 InitialWalletBalance = initialWalletBalance,
-                AssetOneBalance = clientBalanceResponseModels.First(b => b.AssetId == data.TradedAsset).Balance,
-                AssetTwoBalance = clientBalanceResponseModels.First(b => b.AssetId != data.TradedAsset).Balance,
+                InitialTradedAssetBalance = clientBalanceResponseModels.First(b => b.AssetId == data.TradedAsset).Balance,
+                InitialAssetTwoBalance = clientBalanceResponseModels.First(b => b.AssetId != data.TradedAsset).Balance,
+                LastTradedAssetBalance = clientBalanceResponseModels.First(b => b.AssetId == data.TradedAsset).Balance,
+                LastAssetTwoBalance = clientBalanceResponseModels.First(b => b.AssetId != data.TradedAsset).Balance,
                 InstanceId = data.InstanceId,
                 LastWalletBalance = initialWalletBalance,
                 TotalNumberOfStarts = 0,

--- a/src/Lykke.AlgoStore.Services/Lykke.AlgoStore.Services.csproj
+++ b/src/Lykke.AlgoStore.Services/Lykke.AlgoStore.Services.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lykke.AlgoStore.CSharp.AlgoTemplate.Models" Version="1.0.31-beta" />
+    <PackageReference Include="Lykke.AlgoStore.CSharp.AlgoTemplate.Models" Version="1.0.34-beta" />
     <PackageReference Include="Lykke.Common" Version="4.5.0" />
     <PackageReference Include="Lykke.Service.Assets.Client" Version="3.3.2" />
     <PackageReference Include="Lykke.Service.Balances.Client" Version="1.0.21" />

--- a/tests/Lykke.AlgoStore.Tests/Unit/AlgoStoreStatisticsServiceTests.cs
+++ b/tests/Lykke.AlgoStore.Tests/Unit/AlgoStoreStatisticsServiceTests.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using Lykke.AlgoStore.Core.Domain.Repositories;
+using Lykke.AlgoStore.Core.Services;
+using Lykke.AlgoStore.CSharp.AlgoTemplate.Models.Models;
+using Lykke.AlgoStore.CSharp.AlgoTemplate.Models.Repositories;
+using Lykke.AlgoStore.Services;
+using Lykke.AlgoStore.Tests.Infrastructure;
+using Lykke.Service.Assets.Client;
+using Lykke.Service.Assets.Client.Models;
+using Lykke.Service.Balances.AutorestClient.Models;
+using Lykke.Service.PersonalData.Contract;
+using Microsoft.Rest;
+using Moq;
+using NUnit.Framework;
+
+namespace Lykke.AlgoStore.Tests.Unit
+{
+    [TestFixture]
+    public class AlgoStoreStatisticsServiceTests
+    {
+        private readonly string InstanceId = Guid.NewGuid().ToString();
+        private readonly string ClientId = Guid.NewGuid().ToString();
+
+        private const string TradedAsset = "BTC";
+        private const string QuotingAsset = "USD";
+        private const string AssetPair = "BTCUSD";
+
+        [Test]
+        public void GetStatisticsSummary()
+        {
+            var statisticsRepo = Given_Correct_StatisticsRepository();
+            var algoInstanceRepo = Given_Correct_AlgoClientInstanceRepository();
+            var walletBalanceService = Given_Customized_WalletBalanceServiceMock();
+            var assetsService = Given_Customized_AssetServiceMock();
+            var statisticsService = Given_Correct_AlgoStoreStatisticsService(statisticsRepo, algoInstanceRepo,
+                walletBalanceService, assetsService);
+
+            var result = When_Invoke_GetStatisticsSummaryAsync(statisticsService, ClientId, InstanceId, out Exception ex);
+            Then_Exception_Should_BeNull(ex);
+            Then_Object_Should_NotBeNull(result);
+        }
+
+        [Test]
+        public void UpdateStatisticsSummary()
+        {
+            var statisticsRepo = Given_Correct_StatisticsRepository();
+            var algoInstanceRepo = Given_Correct_AlgoClientInstanceRepository();
+            var walletBalanceService = Given_Customized_WalletBalanceServiceMock();
+            var assetsService = Given_Customized_AssetServiceMock();
+            var statisticsService = Given_Correct_AlgoStoreStatisticsService(statisticsRepo, algoInstanceRepo,
+                walletBalanceService, assetsService);
+
+            var result = When_Invoke_UpdateStatisticsSummaryAsync(statisticsService, ClientId, InstanceId, out Exception ex);
+            Then_Exception_Should_BeNull(ex);
+            Then_Object_Should_NotBeNull(result);
+        }
+
+        #region Private methods
+
+        private static AlgoStoreStatisticsService Given_Correct_AlgoStoreStatisticsService(IStatisticsRepository statisticsRepository,
+            IAlgoClientInstanceRepository algoClientInstanceRepository,
+            IWalletBalanceService walletBalanceService, IAssetsService assetsService)
+        {
+            return new AlgoStoreStatisticsService(statisticsRepository, algoClientInstanceRepository, walletBalanceService, assetsService, new LogMock());
+        }
+
+        private static IStatisticsRepository Given_Correct_StatisticsRepository()
+        {
+            var fixture = new Fixture();
+            var result = new Mock<IStatisticsRepository>();
+
+            result.Setup(repo => repo.GetSummaryAsync(It.IsAny<string>())).Returns((string algoId) =>
+            {
+                var comment = fixture.Build<StatisticsSummary>()
+                    .Create();
+                return Task.FromResult(comment);
+            });
+
+            result.Setup(repo => repo.CreateOrUpdateSummaryAsync(It.IsAny<StatisticsSummary>())).Returns((StatisticsSummary summary) => Task.FromResult(summary));
+
+            return result.Object;
+        }
+
+        private static IAlgoClientInstanceRepository Given_Correct_AlgoClientInstanceRepository()
+        {
+            var fixture = new Fixture();
+            var result = new Mock<IAlgoClientInstanceRepository>();
+
+            result.Setup(repo => repo.GetAlgoInstanceDataByClientIdAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string clientId, string id) =>
+                {
+                    return Task.FromResult(fixture.Build<AlgoClientInstanceData>()
+                        .With(a => a.ClientId, clientId)
+                        .With(b => b.InstanceId, id)
+                        .With(a => a.TradedAsset, TradedAsset)
+                        .With(a => a.AssetPair, AssetPair)
+                        .Create());
+                });
+
+            return result.Object;
+        }
+
+        private static IWalletBalanceService Given_Customized_WalletBalanceServiceMock()
+        {
+            var fixture = new Fixture();
+            var result = new Mock<IWalletBalanceService>();
+
+            result.Setup(service => service.GetTotalWalletBalanceInBaseAssetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<AssetPair>()))
+                .ReturnsAsync(100);
+
+            result.Setup(service => service.GetWalletBalancesAsync(It.IsAny<string>(), It.IsAny<AssetPair>()))
+                .ReturnsAsync(new List<ClientBalanceResponseModel>
+                {
+                    fixture.Build<ClientBalanceResponseModel>()
+                        .With(w => w.AssetId, TradedAsset)
+                        .Create(),
+
+                    fixture.Build<ClientBalanceResponseModel>()
+                        .With(w => w.AssetId, QuotingAsset)
+                        .Create()
+                });
+
+
+            return result.Object;
+        }
+
+        private static IAssetsService Given_Customized_AssetServiceMock()
+        {
+            var fixture = new Fixture();
+            var result = new Mock<IAssetsService>();
+
+            result.Setup(service => service.AssetPairGetWithHttpMessagesAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, List<string>>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new HttpOperationResponse<AssetPair>
+                {
+                    Body = fixture.Build<AssetPair>()
+                        .With(pair => pair.IsDisabled, false)
+                        .Create(),
+                    Response = new HttpResponseMessage(HttpStatusCode.OK)
+                });
+
+            result.Setup(service => service.AssetGetWithHttpMessagesAsync(It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, List<string>>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new HttpOperationResponse<Asset>
+                {
+                    Body = fixture.Build<Asset>()
+                        .With(asset => asset.IsDisabled, false)
+                        .Create(),
+                    Response = new HttpResponseMessage(HttpStatusCode.OK)
+                });
+
+            return result.Object;
+        }
+
+        private static StatisticsSummary When_Invoke_GetStatisticsSummaryAsync(IAlgoStoreStatisticsService service, string clientId, string instanceId, out Exception exception)
+        {
+            exception = null;
+            try
+            {
+                return service.GetStatisticsSummaryAsync(clientId, instanceId).Result;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+                return null;
+            }
+        }
+
+        private static StatisticsSummary When_Invoke_UpdateStatisticsSummaryAsync(IAlgoStoreStatisticsService service, string clientId, string instanceId, out Exception exception)
+        {
+            exception = null;
+            try
+            {
+                return service.UpdateStatisticsSummaryAsync(clientId, instanceId).Result;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+                return null;
+            }
+        }
+
+        private static void Then_Exception_Should_BeNull(Exception ex)
+        {
+            Assert.IsNull(ex);
+        }
+
+        private static void Then_Object_Should_NotBeNull(StatisticsSummary data)
+        {
+            Assert.NotNull(data);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
… the endpoint for retrieving statistics summary, do not update it with latest balances if instance is stopped. Add Statistics Service unit tests